### PR TITLE
Supports multiple ElasticSearch/OpenSearch

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -7958,7 +7958,7 @@ func GetEsConfig() *elasticsearch.Client {
 
 	// https://github.com/elastic/go-elasticsearch/blob/f741c073f324c15d3d401d945ee05b0c410bd06d/elasticsearch.go#L98
 	config := elasticsearch.Config{
-		Addresses: []string{esUrl},
+		Addresses: strings.Split(esUrl, ","),
 		Username:  os.Getenv("SHUFFLE_OPENSEARCH_USERNAME"),
 		Password:  os.Getenv("SHUFFLE_OPENSEARCH_PASSWORD"),
 		APIKey:    os.Getenv("SHUFFLE_OPENSEARCH_APIKEY"),


### PR DESCRIPTION
Supports multiple ElasticSearch/OpenSearch connection string. There is a case where OpenSearch contains more than one node, therefore it is necessary to support multiple OpenSearch nodes.
E.g. SHUFFLE_OPENSEARCH_URL=http://os1:9200,http://os2:9200,http://os3:9200