### PR TITLE
fix: return from ElasticSearch index should be checked

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -3091,7 +3091,7 @@ func SetWorkflowAppAuthDatastore(ctx context.Context, workflowappauth AppAuthent
 			return err
 		}
 
-		indexEs(ctx, nameKey, id, data)
+		err = indexEs(ctx, nameKey, id, data)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The fix includes check of indexEs() return which has not been assigned to err.  